### PR TITLE
Wired up support for smtp_should_reject API in container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,13 @@ RUN >/etc/postfix/main.cf \
 	&& postconf -e alias_maps= \
 	&& postconf -e mynetworks='127.0.0.0/8 [::1]/128 [fe80::]/64' \
 	&& postconf -e transport_maps=hash:/etc/postfix/transport \
+	&& postconf -e 'smtpd_recipient_restrictions = check_policy_service unix:private/policy' \
 	&& postconf -M -e 'discourse/unix=discourse unix - n n - - pipe user=nobody:nogroup argv=/usr/local/bin/receive-mail ${recipient}' \
+	&& postconf -M -e 'policy/unix=policy unix - n n - - spawn user=nobody argv=/usr/local/bin/discourse-smtp-fast-rejection.rb' \
 	&& rm -rf /var/spool/postfix/*
 
 COPY receive-mail /usr/local/bin/
+COPY discourse-smtp-fast-rejection.rb /usr/local/bin/
 COPY boot /sbin/
 COPY fake-pups /pups/bin/pups
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ This involves setting the following environment variables:
   `https://example.com/forum` ->
   `https://example.com/forum/admin/email/handle_mail`).
 
+* `DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT` -- the complete URL to the API
+  endpoint for aiding fast rejection at the SMTP level. This will be whatever
+  your Discourse site URL is, with `/admin/email/smtp_should_reject.json`
+  appended.  For example, if people normally visit your Discourse forum by
+  going to `https://discourse.example.com`, this environment variable should be
+  set to `https://discourse.example.com/admin/email/smtp_should_reject.json`.
+  If you're running a subfolder setup, be sure to account for that (ie
+  `https://example.com/forum` ->
+  `https://example.com/forum/admin/email/smtp_should_reject.json`).
+
 * `DISCOURSE_API_KEY` -- the API key which will be used to authenticate to
   Discourse in order to submit mail.  The value to use is shown in the "API"
   tab of the site admin dashboard.
@@ -72,3 +82,11 @@ specified URL (`DISCOURSE_MAIL_ENDPOINT`), with the key and username
 specified.  Discourse itself stands ready to receive that e-mail and process
 it into the discussion, in exactly the same way as an e-mail received via
 POP3 polling.
+
+Before delivery to the `discourse` service, a Postfix policy handler runs,
+asks Discourse if either the sender and/or recipient are invalid, and if so,
+rejects the incoming mail during the SMTP transaction, to prevent Discourse
+later sending out reply emails due to incoming spam ("backscatter").
+Legitimate users will be notified of the failure by their MTA, and obvious
+spam just gets dropped without reply. This step is just about being a good
+citizen of the Internet and not full spam filtering.

--- a/README.md
+++ b/README.md
@@ -13,25 +13,10 @@ This involves setting the following environment variables:
 * `MAIL_DOMAIN` -- the domain name(s) to accept mail for and relay to
   Discourse.  Any number of space-separated domain names can be listed here.
 
-* `DISCOURSE_MAIL_ENDPOINT` -- the complete URL to the API endpoint for
-  receiving incoming e-mail.  This will be whatever your Discourse site URL
-  is, with `/admin/email/handle_mail` appended.  For example, if people
-  normally visit your Discourse forum by going to
-  `https://discourse.example.com`, this environment variable should be set
-  to `https://discourse.example.com/admin/email/handle_mail`.  If you're
-  running a subfolder setup, be sure to account for that (ie
-  `https://example.com/forum` ->
-  `https://example.com/forum/admin/email/handle_mail`).
-
-* `DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT` -- the complete URL to the API
-  endpoint for aiding fast rejection at the SMTP level. This will be whatever
-  your Discourse site URL is, with `/admin/email/smtp_should_reject.json`
-  appended.  For example, if people normally visit your Discourse forum by
-  going to `https://discourse.example.com`, this environment variable should be
-  set to `https://discourse.example.com/admin/email/smtp_should_reject.json`.
-  If you're running a subfolder setup, be sure to account for that (ie
-  `https://example.com/forum` ->
-  `https://example.com/forum/admin/email/smtp_should_reject.json`).
+* `DISCOURSE_BASE_URL` -- the base URL for this Discourse instance.
+  This will be whatever your Discourse site URL is. For example,
+  `https://discourse.example.com`. If you're running a subfolder setup,
+  be sure to account for that (ie `https://example.com/forum`).
 
 * `DISCOURSE_API_KEY` -- the API key which will be used to authenticate to
   Discourse in order to submit mail.  The value to use is shown in the "API"
@@ -78,10 +63,10 @@ container and process syslog entries intelligently (such as, say,
 
 Every e-mail that is received is delivered to a custom `discourse` service.
 That service, which is a small Ruby program, makes a POST request to the
-specified URL (`DISCOURSE_MAIL_ENDPOINT`), with the key and username
-specified.  Discourse itself stands ready to receive that e-mail and process
-it into the discussion, in exactly the same way as an e-mail received via
-POP3 polling.
+admin interface on the specified URL (`DISCOURSE_BASE_URL`), with the key
+and username specified.  Discourse itself stands ready to receive that
+e-mail and process it into the discussion, in exactly the same way as an
+e-mail received via POP3 polling.
 
 Before delivery to the `discourse` service, a Postfix policy handler runs,
 asks Discourse if either the sender and/or recipient are invalid, and if so,

--- a/boot
+++ b/boot
@@ -29,7 +29,7 @@ done
 /usr/sbin/postmap /etc/postfix/transport
 
 # Make sure the necessary Discourse connection details are in place
-for v in DISCOURSE_MAIL_ENDPOINT DISCOURSE_API_KEY DISCOURSE_API_USERNAME; do
+for v in DISCOURSE_BASE_URL DISCOURSE_API_KEY DISCOURSE_API_USERNAME; do
 	if [ -z "${!v}" ]; then
 		echo "FATAL ERROR: $v env var is not set." >&2
 		exit 1

--- a/discourse-smtp-fast-rejection.rb
+++ b/discourse-smtp-fast-rejection.rb
@@ -24,7 +24,7 @@ def main
 
   real_env = JSON.parse(File.read(ENV_FILE))
 
-  %w{DISCOURSE_MAIL_ENDPOINT DISCOURSE_API_KEY DISCOURSE_API_USERNAME}.each do |kw|
+  %w{DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT DISCOURSE_API_KEY DISCOURSE_API_USERNAME}.each do |kw|
     fatal "env var %s is required", kw unless real_env[kw]
   end
 

--- a/discourse-smtp-fast-rejection.rb
+++ b/discourse-smtp-fast-rejection.rb
@@ -1,0 +1,115 @@
+#!/usr/bin/env ruby
+
+require 'syslog'
+require 'json'
+require 'uri'
+require 'net/http'
+
+ENV_FILE = "/etc/postfix/mail-receiver-environment.json"
+
+def logger
+  @logger ||= Syslog.open("smtp-reject", Syslog::LOG_PID, Syslog::LOG_MAIL)
+end
+
+def fatal(*args)
+  logger.crit *args
+  exit 1
+end
+
+def main
+  unless File.exists?(ENV_FILE)
+    fatal "Config file %s does not exist. Aborting.", ENV_FILE
+  end
+
+  real_env = JSON.parse(File.read(ENV_FILE))
+
+  %w{DISCOURSE_MAIL_ENDPOINT DISCOURSE_API_KEY DISCOURSE_API_USERNAME}.each do |kw|
+    fatal "env var %s is required", kw unless real_env[kw]
+  end
+
+  process_requests(real_env)
+end
+
+def process_requests(env)
+  $stdout.sync = true   # unbuffered output
+
+  args = {}
+  while line = gets
+    # Fill up args with the request details.
+    line = line.chomp
+    if !line.empty?
+      k,v = line.chomp.split('=', 2)
+      args[k] = v;
+      next
+    end
+
+    process_single_request(args, env)
+    args = {}  # reset for next request.
+  end
+end
+
+def process_single_request(args, env)
+  action = 'dunno'
+  if args['request'] != 'smtpd_access_policy'
+    action = 'defer_if_permit Internal error'
+  elsif args['protocol_state'] != 'RCPT'
+    action = 'dunno' 
+  elsif args['sender'].nil? || args['recipient'].nil?
+    action = 'defer_if_permit Internal error'
+  else
+    action = maybe_reject_email(args['sender'], args['recipient'], env)
+  end
+
+  puts "action=#{action}"
+  puts ''
+end
+
+def escapeApiArg(str)
+  retval = URI.escape(str)  # do default unsafe chars
+  retval = URI.escape(str, '+')  # '+' isn't in the default unsafe list, but Discourse needs it escaped.
+  return retval
+end
+
+def maybe_reject_email(from, to, env)
+  endpoint = env["DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT"]
+  key = env["DISCOURSE_API_KEY"]
+  username = env["DISCOURSE_API_USERNAME"]
+
+  uri = URI.parse(endpoint)
+  fromarg = escapeApiArg(from)
+  toarg = escapeApiArg(to)
+
+  api_qs = "api_key=#{key}&api_username=#{username}&from=#{fromarg}&to=#{toarg}"
+  if uri.query and !uri.query.empty?
+    uri.query += "&#{api_qs}"
+  else
+    uri.query = api_qs
+  end
+
+  begin
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
+    get = Net::HTTP::Get.new(uri.request_uri)
+    response = http.request(get)
+  rescue StandardError => ex
+    logger.err "Failed to GET smtp_should_reject answer from %s: %s (%s)", endpoint, ex.message, ex.class
+    logger.err ex.backtrace.map { |l| "  #{l}" }.join("\n")
+    return "defer_if_permit Internal error"
+  ensure
+    http.finish if http && http.started?
+  end
+
+  if Net::HTTPSuccess === response
+    reply = JSON.parse(response.body)
+    if reply['reject']
+      return "reject #{reply['reason']}"
+    end
+  else
+    logger.err "Failed to GET smtp_should_reject answer from %s: %s", endpoint, response.code
+    return "defer_if_permit Internal error"
+  end
+
+  return "dunno"  # let future tests also be allowed to reject this one.
+end
+
+main if __FILE__ == $0

--- a/discourse-smtp-fast-rejection.rb
+++ b/discourse-smtp-fast-rejection.rb
@@ -38,14 +38,13 @@ def process_requests(env)
   while line = gets
     # Fill up args with the request details.
     line = line.chomp
-    if !line.empty?
+    if line.empty?
+      process_single_request(args, env)
+      args = {}  # reset for next request.
+    else
       k,v = line.chomp.split('=', 2)
-      args[k] = v;
-      next
+      args[k] = v
     end
-
-    process_single_request(args, env)
-    args = {}  # reset for next request.
   end
 end
 

--- a/discourse-smtp-fast-rejection.rb
+++ b/discourse-smtp-fast-rejection.rb
@@ -3,6 +3,7 @@
 require 'syslog'
 require 'json'
 require 'uri'
+require 'cgi'
 require 'net/http'
 
 ENV_FILE = "/etc/postfix/mail-receiver-environment.json"
@@ -64,20 +65,14 @@ def process_single_request(args, env)
   puts ''
 end
 
-def escapeApiArg(str)
-  retval = URI.escape(str)  # do default unsafe chars
-  retval = URI.escape(str, '+')  # '+' isn't in the default unsafe list, but Discourse needs it escaped.
-  return retval
-end
-
 def maybe_reject_email(from, to, env)
   endpoint = env["DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT"]
   key = env["DISCOURSE_API_KEY"]
   username = env["DISCOURSE_API_USERNAME"]
 
   uri = URI.parse(endpoint)
-  fromarg = escapeApiArg(from)
-  toarg = escapeApiArg(to)
+  fromarg = CGI::escape(from)
+  toarg = CGI::escape(to)
 
   api_qs = "api_key=#{key}&api_username=#{username}&from=#{fromarg}&to=#{toarg}"
   if uri.query and !uri.query.empty?

--- a/discourse-smtp-fast-rejection.rb
+++ b/discourse-smtp-fast-rejection.rb
@@ -24,7 +24,7 @@ def main
 
   real_env = JSON.parse(File.read(ENV_FILE))
 
-  %w{DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT DISCOURSE_API_KEY DISCOURSE_API_USERNAME}.each do |kw|
+  %w{DISCOURSE_BASE_URL DISCOURSE_API_KEY DISCOURSE_API_USERNAME}.each do |kw|
     fatal "env var %s is required", kw unless real_env[kw]
   end
 
@@ -67,7 +67,7 @@ def process_single_request(args, env)
 end
 
 def maybe_reject_email(from, to, env)
-  endpoint = env["DISCOURSE_SMTP_SHOULD_REJECT_ENDPOINT"]
+  endpoint = "#{env['DISCOURSE_BASE_URL']}/admin/email/smtp_should_reject.json"
   key = env["DISCOURSE_API_KEY"]
   username = env["DISCOURSE_API_USERNAME"]
 

--- a/receive-mail
+++ b/receive-mail
@@ -25,7 +25,7 @@ def main
 
 	real_env = JSON.parse(File.read(ENV_FILE))
 
-	%w{DISCOURSE_MAIL_ENDPOINT DISCOURSE_API_KEY DISCOURSE_API_USERNAME}.each do |kw|
+	%w{DISCOURSE_BASE_URL DISCOURSE_API_KEY DISCOURSE_API_USERNAME}.each do |kw|
 		fatal "env var %s is required", kw unless real_env[kw]
 	end
 
@@ -45,7 +45,7 @@ rescue StandardError => ex
 end
 
 def post_email(_recipient, mail, env)
-	endpoint = env["DISCOURSE_MAIL_ENDPOINT"]
+	endpoint = "#{env['DISCOURSE_BASE_URL']}/admin/email/handle_mail"
 	key      = env["DISCOURSE_API_KEY"]
 	username = env["DISCOURSE_API_USERNAME"]
 


### PR DESCRIPTION
These are the changes needed to the mail-receiver container to fight backscatter. This isn't tested because I have no idea what I'm doing.  :)

The discussion that led to this is here: https://meta.discourse.org/t/reducing-backscatter-in-email-interface/59974

There is also a minor PR for discourse/discourse_docker, to add an environment variable to its samples/mail-receiver.yml: https://github.com/discourse/discourse_docker/pull/344

(EDIT: updated with PR url.)