### PR TITLE
FEATURE: Do not apply FastRejection to irrelevant domains

### DIFF
--- a/lib/mail_receiver/fast_rejection.rb
+++ b/lib/mail_receiver/fast_rejection.rb
@@ -16,6 +16,7 @@ class FastRejection < MailReceiverBase
     @disabled = @env['DISCOURSE_FAST_REJECTION_DISABLED'] || !@env['DISCOURSE_BASE_URL']
 
     @blacklisted_sender_domains = @env.fetch('BLACKLISTED_SENDER_DOMAINS', "").split(" ").map(&:downcase).to_set
+    @mail_domain = @env.fetch('MAIL_DOMAIN', "").split(" ").map(&:downcase).to_set
   end
 
   def disabled?
@@ -136,7 +137,13 @@ class FastRejection < MailReceiverBase
   end
 
   def maybe_reject_by_api(args)
-    maybe_reject_email(args['sender'], args['recipient'])
+    sender = args['sender']
+    recipient = args['recipient']
+
+    domain = domain_from_addrspec(recipient)
+    return "dunno" unless @mail_domain.include? domain
+
+    maybe_reject_email(sender, recipient)
   end
 
 end

--- a/spec/fixtures/standard.json
+++ b/spec/fixtures/standard.json
@@ -2,5 +2,6 @@
 	"DISCOURSE_API_KEY": "EXAMPLE_KEY",
 	"DISCOURSE_API_USERNAME": "eviltrout",
 	"DISCOURSE_BASE_URL": "https://localhost:8080",
+	"MAIL_DOMAIN": "example.com EXAMPLE.ORG",
 	"BLACKLISTED_SENDER_DOMAINS": "bad.com SAD.NET"
 }

--- a/spec/lib/fast_reject_spec.rb
+++ b/spec/lib/fast_reject_spec.rb
@@ -101,6 +101,16 @@ describe FastRejection do
       expect(response).to start_with('reject')
     end
 
+    it "returns dunno if recipient domain is not a mail domain" do
+      response = receiver.process_single_request(
+        'request' => 'smtpd_access_policy',
+        'protocol_state' => 'RCPT',
+        'sender' => 'eviltrout@example.com',
+        'recipient' => 'discourse@example.net'
+      )
+      expect(response).to start_with('dunno')
+    end
+
     it "returns dunno if everything looks good" do
       expect_any_instance_of(Net::HTTP).to receive(:request) do |http|
         response = Net::HTTPSuccess.new(http, 200, "OK")
@@ -112,6 +122,21 @@ describe FastRejection do
         'protocol_state' => 'RCPT',
         'sender' => 'eviltrout@example.com',
         'recipient' => 'discourse@example.com'
+      )
+      expect(response).to eq("dunno")
+    end
+
+    it "returns dunno if everything looks good with differing case receiver domain" do
+      expect_any_instance_of(Net::HTTP).to receive(:request) do |http|
+        response = Net::HTTPSuccess.new(http, 200, "OK")
+        expect(response).to receive(:body) { "{}" }
+        response
+      end
+      response = receiver.process_single_request(
+        'request' => 'smtpd_access_policy',
+        'protocol_state' => 'RCPT',
+        'sender' => 'eviltrout@example.com',
+        'recipient' => 'discourse@example.org'
       )
       expect(response).to eq("dunno")
     end


### PR DESCRIPTION
When Postfix should be able to handle other mail traffic too,
`FastRejection` must ignore domains, which are not listed in the
`MAIL_DOMAIN` environment variable.

There is no change in behaviour for the current Docker container, since
Postfix accepts only mail for domains listed in`MAIL_DOMAIN` anyway.