### PR TITLE
Upgrade ruby and alpine.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ruby:2.3-alpine
+FROM debian:buster-slim
 
-RUN apk update \
-	&& apk add postfix socat bash \
-	&& rm -f /var/cache/apk/*
+RUN DEBIAN_FRONTEND=noninteractive apt update \
+	&& DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends curl perl postfix ruby socat \
+	&& DEBIAN_FRONTEND=noninteractive apt -y --purge autoremove \
+	&& DEBIAN_FRONTEND=noninteractive apt clean
 
 EXPOSE 25
 VOLUME /var/spool/postfix
@@ -27,8 +28,8 @@ COPY lib/ /usr/local/lib/ruby/site_ruby/
 COPY boot /sbin/
 COPY fake-pups /pups/bin/pups
 
-ADD https://github.com/discourse/socketee/releases/download/v0.0.2/socketee /usr/local/bin/
-RUN echo '7cd6df7aeeac0cce35c84e842b3cda5a4c36a301  /usr/local/bin/socketee' | sha1sum -c - \
+RUN curl -sL https://github.com/discourse/socketee/releases/download/v0.0.2/socketee -o /usr/local/bin/socketee \
+	&& echo '7cd6df7aeeac0cce35c84e842b3cda5a4c36a301  /usr/local/bin/socketee' | sha1sum -c - \
 	&& chmod 0755 /usr/local/bin/socketee
 
 CMD ["/sbin/boot"]

--- a/boot
+++ b/boot
@@ -59,4 +59,4 @@ chown root:root /var/spool/postfix
 echo "Starting Postfix" >&2
 
 # Finally, let postfix-master do its thing
-exec /usr/lib/postfix/master -c /etc/postfix -d
+exec /usr/lib/postfix/sbin/master -c /etc/postfix -d


### PR DESCRIPTION
Move mail-receiver to debian buster image base.
Rather than relying on the upstream ruby repositories backporting
security fixes, move to the debian buster for more reliable upstream
updates. Bleeding edge ruby is not required for these images (note ruby
2.5 is the default on debian buster).

Incidentally this updates ruby to 2.5 and postfix to 3.4.14.

Note that the following warning emitted by postfix can be ignored
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=926331#13
```
postfix/postfix-script[86]: warning: symlink leaves directory:
/etc/postfix/./makedefs.out
```

