### PR TITLE
Enable STARTTLS in postfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye-slim
 
 RUN DEBIAN_FRONTEND=noninteractive apt update \
-	&& DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends curl perl postfix ruby socat \
+	&& DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends curl perl postfix ruby socat ssl-cert \
 	&& DEBIAN_FRONTEND=noninteractive apt -y --purge autoremove \
 	&& DEBIAN_FRONTEND=noninteractive apt clean
 
@@ -19,6 +19,17 @@ RUN >/etc/postfix/main.cf \
 	&& postconf -e mynetworks='127.0.0.0/8 [::1]/128 [fe80::]/64' \
 	&& postconf -e transport_maps=hash:/etc/postfix/transport \
 	&& postconf -e 'smtpd_recipient_restrictions = check_policy_service unix:private/policy' \
+	&& postconf -e smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem \
+	&& postconf -e smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key \
+	&& postconf -e smtpd_tls_security_level=may \
+	&& postconf -e smtpd_tls_ciphers=HIGH \
+	&& postconf -e smtpd_tls_mandatory_ciphers=HIGH \
+	&& postconf -e 'smtpd_tls_protocols = TLSv1.2 TLSv1.3' \
+	&& postconf -e 'smtpd_tls_exclude_ciphers = aNULL MD5 SHA CAMELLIA' \
+	&& postconf -e 'smtpd_tls_mandatory_exclude_ciphers = aNULL MD5 SHA CAMELLIA' \
+	&& postconf -e 'tls_eecdh_auto_curves = X448 X25519 secp521r1 secp384r1 prime256v1' \
+	&& postconf -e tls_preempt_cipherlist=yes \
+	&& postconf -e tls_ssl_options=NO_RENEGOTIATION \
 	&& postconf -M -e 'discourse/unix=discourse unix - n n - - pipe user=nobody:nogroup argv=/usr/local/bin/receive-mail ${recipient}' \
 	&& postconf -M -e 'policy/unix=policy unix - n n - - spawn user=nobody argv=/usr/local/bin/discourse-smtp-fast-rejection' \
 	&& rm -rf /var/spool/postfix/*


### PR DESCRIPTION
Encryption of emails is important and should be included in the default configuration. This pull request adds a reasonably modern TLS configuration to postfix, which allows receiving emails with encryption, rather than plain text.
Ideally an operator should use a TLS certificate matching their domain, but a self-signed certificate, as included with this configuration, is better than nothing.