### PR TITLE
Encode the mails for the new api

### DIFF
--- a/lib/mail_receiver/discourse_mail_receiver.rb
+++ b/lib/mail_receiver/discourse_mail_receiver.rb
@@ -3,6 +3,7 @@ require 'syslog'
 require 'json'
 require "uri"
 require "net/http"
+require "base64"
 require_relative 'mail_receiver_base'
 
 class DiscourseMailReceiver < MailReceiverBase
@@ -38,7 +39,7 @@ class DiscourseMailReceiver < MailReceiverBase
       post = Net::HTTP::Post.new(uri.request_uri)
       post["Api-Username"] = username
       post["Api-Key"] = key
-      post.set_form_data(email: @mail)
+      post.set_form_data(email_encoded: Base64.strict_encode64(@mail))
 
       response = http.request(post)
     rescue StandardError => ex

--- a/lib/mail_receiver/mail_receiver_base.rb
+++ b/lib/mail_receiver/mail_receiver_base.rb
@@ -5,7 +5,7 @@ class MailReceiverBase
   attr_reader :env
 
   def initialize(env_file)
-    unless File.exists?(env_file)
+    unless File.exist?(env_file)
       fatal "Config file %s does not exist. Aborting.", env_file
     end
 


### PR DESCRIPTION
The new api produces a warning regarding the use of `email` form parameter. This replaces it with `email_encoded`. It also makes sure that this code works with ruby 3.2 by changing `File#exists?` to `File#exist?`