### PR TITLE
DEV: update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler
   discourse_mail_receiver!
   rake
   rspec
@@ -114,4 +115,4 @@ DEPENDENCIES
   syntax_tree-disable_ternary
 
 BUNDLED WITH
-   2.1.4
+   2.5.16

--- a/discourse_mail_receiver.gemspec
+++ b/discourse_mail_receiver.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "mail", "~> 2.7.1"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop-discourse"


### PR DESCRIPTION
Fixing the deprecation messages that appear under Ruby 3 and from rubocop.
```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

https://github.com/rubygems/rubygems/issues/5234