### PR TITLE
FIX: upgrade to bookworm for ruby 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG INCLUDE_DMARC=true
 ENV INCLUDE_DMARC=${INCLUDE_DMARC}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     discourse_mail_receiver (4.1.0)
       mail (~> 2.7.1)
+      net-smtp (~> 0.3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -33,6 +34,10 @@ GEM
     mini_mime (1.1.5)
     minitest (5.24.1)
     mutex_m (0.2.0)
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
     parallel (1.25.1)
     parser (3.3.4.0)
       ast (~> 2.4.1)
@@ -98,6 +103,7 @@ GEM
     syntax_tree (6.2.0)
       prettier_print (>= 1.2.0)
     syntax_tree-disable_ternary (1.0.0)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -114,4 +120,4 @@ DEPENDENCIES
   syntax_tree-disable_ternary
 
 BUNDLED WITH
-   2.1.4
+   2.5.16

--- a/discourse_mail_receiver.gemspec
+++ b/discourse_mail_receiver.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "mail", "~> 2.7.1"
+  spec.add_runtime_dependency "net-smtp", "~> 0.3.3"
+
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop-discourse"

--- a/lib/mail_receiver/fast_rejection.rb
+++ b/lib/mail_receiver/fast_rejection.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+
+# rubocop:disable Lint/RedundantRequireStatement
+# require "set" is needed for Set
+require "set"
 require "syslog"
 require "json"
 require "uri"
@@ -15,7 +19,7 @@ class FastRejection < MailReceiverBase
     @disabled = @env["DISCOURSE_FAST_REJECTION_DISABLED"] || !@env["DISCOURSE_BASE_URL"]
 
     @blacklisted_sender_domains =
-      @env.fetch("BLACKLISTED_SENDER_DOMAINS", "").split(" ").map(&:downcase).to_set
+      Set.new(@env.fetch("BLACKLISTED_SENDER_DOMAINS", "").split(" ").map(&:downcase))
   end
 
   def disabled?


### PR DESCRIPTION
Current `main` is failing due to the missing require statement for Set. Debian-bullseye's version of ruby is already EOL as well, so I opted to upgrade the image to bookworm which comes with Ruby 3.2.

#### Testing

Remote site able to receive email https://kelv.demo-by-discourse.com/t/test-topic-kelvtyb-disco-mail-receiver-dmarc-v3/20

<img width="550" alt="incoming email success" src="https://github.com/user-attachments/assets/899b337f-7e19-4eb9-9803-e826e9c1e07d">
