### PR TITLE
Remove socketee support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,4 @@ COPY lib/ /usr/local/lib/site_ruby/
 COPY boot /sbin/
 COPY fake-pups /pups/bin/pups
 
-RUN curl -sL https://github.com/discourse/socketee/releases/download/v0.0.2/socketee -o /usr/local/bin/socketee \
-	&& echo '7cd6df7aeeac0cce35c84e842b3cda5a4c36a301  /usr/local/bin/socketee' | sha1sum -c - \
-	&& chmod 0755 /usr/local/bin/socketee
-
 CMD ["/sbin/boot"]

--- a/README.md
+++ b/README.md
@@ -58,20 +58,6 @@ The `BLACKLISTED_SENDER_DOMAINS` environment variable accepts a
 space-separated list of domain names.  Mail messages from these senders will
 be fast-failed with SMTP code 554.
 
-
-## Syslog integration
-
-Postfix loves to log everything to syslog.  In fact, that's really all it
-supports.  Since, by default, Docker is not known for its superlative
-out-of-the-box syslog integration, this container runs a tiny script which
-reads all syslog data and dumps it to the container's `stderr` (which is
-then examinable by `docker logs`).
-
-If, by some chance, you want to process your Postfix logs more extensively,
-you can set `SOCKETEE_RELAY_SOCKET` and all syslog messages will also be
-sent to that socket for further processing.
-
-
 # Theory of Operation
 
 Every e-mail that is received is delivered to a custom `discourse` service.

--- a/boot
+++ b/boot
@@ -2,13 +2,13 @@
 
 set -e
 
-# Send syslog messages to stderr, optionally relaying them to another socket
-# for postfix-exporter to take a look at
-if [ -z "$SOCKETEE_RELAY_SOCKET" ]; then
-	/usr/bin/socat UNIX-RECV:/dev/log,mode=0666 stderr &
-else
-	/usr/local/bin/socketee /dev/log "$SOCKETEE_RELAY_SOCKET" &
+if [ "$SOCKETEE_RELAY_SOCKET" ]; then
+	echo "FATAL ERROR: You have defined SOCKETEE_RELAY_SOCKET which is no longer supported" >&2
+	exit 1
 fi
+
+# Send syslog messages to stderr
+/usr/bin/socat UNIX-RECV:/dev/log,mode=0666 stderr &
 
 echo "Operating environment:" >&2
 env >&2


### PR DESCRIPTION
Why remove socketee support?

* The upstream https://github.com/discourse/socketee/ project has been archived.
* socketee is not built for ARM64 and it breaks building / running this image on ARM64.

