### PR TITLE
Add multi-site support: route mail to different Discourse instances by domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,40 @@ complicated setup, the following subsections may provide you with the power
 you need.
 
 
+## Multi-site configuration
+
+A single mail-receiver container can deliver mail to multiple Discourse
+instances.  List all domains in `MAIL_DOMAIN` and provide per-domain
+overrides for the connection variables.
+
+Per-domain variable names are formed by appending an underscore and the
+domain name — with dots and hyphens replaced by underscores, uppercased —
+to the standard variable name.  For example, for `site1.com`:
+
+* `DISCOURSE_BASE_URL_SITE1_COM`
+* `DISCOURSE_API_KEY_SITE1_COM`
+* `DISCOURSE_API_USERNAME_SITE1_COM` (optional, falls back to global)
+* `BLACKLISTED_SENDER_DOMAINS_SITE1_COM` (optional, falls back to global)
+
+A minimal two-site example:
+
+```
+MAIL_DOMAIN="site1.com site2.net"
+
+DISCOURSE_BASE_URL_SITE1_COM=https://site1.com
+DISCOURSE_API_KEY_SITE1_COM=key-for-site1
+
+DISCOURSE_BASE_URL_SITE2_NET=https://site2.net
+DISCOURSE_API_KEY_SITE2_NET=key-for-site2
+
+# Shared across all sites that don't override it
+DISCOURSE_API_USERNAME=system
+```
+
+Any variable not set at the domain level falls back to the global value,
+so shared settings (like `DISCOURSE_API_USERNAME`) only need to be set once.
+
+
 ## Customised Postfix configuration
 
 You can setup any Postfix configuration variables you need by setting env

--- a/boot
+++ b/boot
@@ -28,18 +28,43 @@ for d in $MAIL_DOMAIN; do
 done
 /usr/sbin/postmap /etc/postfix/transport
 
-# Make sure the necessary Discourse connection details are in place
-for v in DISCOURSE_API_KEY DISCOURSE_API_USERNAME; do
-	if [ -z "${!v}" ]; then
-		echo "FATAL ERROR: $v env var is not set." >&2
-		exit 1
-	fi
-done
+# Validate config and generate per-domain environment files.
+#
+# Per-domain overrides use the domain name with dots and hyphens replaced by
+# underscores, uppercased, appended to the var name.  For example, for domain
+# "site1.com" set DISCOURSE_BASE_URL_SITE1_COM, DISCOURSE_API_KEY_SITE1_COM,
+# and DISCOURSE_API_USERNAME_SITE1_COM.  Any var not set at the domain level
+# falls back to the global value.
+ruby -rjson << 'RUBY' || exit 1
+  env = ENV.to_hash
+  domains = ENV['MAIL_DOMAIN'].split
+  errors = []
 
-if [ -z "$DISCOURSE_BASE_URL" ] && [ -z "$DISCOURSE_MAIL_ENDPOINT" ] ; then
-	echo "FATAL ERROR: You need to define DISCOURSE_BASE_URL or DISCOURSE_MAIL_ENDPOINT" >&2
-	exit 1
-fi
+  domains.each do |domain|
+    suffix = domain.tr('.-', '_').upcase
+    domain_env = env.dup
+
+    %w[DISCOURSE_BASE_URL DISCOURSE_MAIL_ENDPOINT DISCOURSE_API_KEY DISCOURSE_API_USERNAME BLACKLISTED_SENDER_DOMAINS].each do |key|
+      domain_key = "#{key}_#{suffix}"
+      domain_env[key] = env[domain_key] if env[domain_key]
+    end
+
+    %w[DISCOURSE_API_KEY DISCOURSE_API_USERNAME].each do |key|
+      errors << "#{domain}: #{key} is not set" unless domain_env[key]
+    end
+    unless domain_env['DISCOURSE_BASE_URL'] || domain_env['DISCOURSE_MAIL_ENDPOINT']
+      errors << "#{domain}: DISCOURSE_BASE_URL or DISCOURSE_MAIL_ENDPOINT is not set"
+    end
+
+    File.write("/etc/postfix/mail-receiver-environment-#{domain}.json", domain_env.to_json)
+    STDERR.puts "Generated config for #{domain}"
+  end
+
+  unless errors.empty?
+    errors.each { |e| STDERR.puts "FATAL ERROR: #{e}" }
+    exit 1
+  end
+RUBY
 
 # Generic postfix config setting code... bashers gonna bash.
 for envvar in $(compgen -v); do

--- a/lib/mail_receiver/discourse_mail_receiver.rb
+++ b/lib/mail_receiver/discourse_mail_receiver.rb
@@ -6,6 +6,14 @@ require "net/http"
 require_relative "mail_receiver_base"
 
 class DiscourseMailReceiver < MailReceiverBase
+  ENV_DIR = "/etc/postfix"
+
+  def self.env_file_for_recipient(recipient, base_dir = ENV_DIR)
+    domain = recipient.to_s.split('@').last.to_s.downcase
+    domain_file = "#{base_dir}/mail-receiver-environment-#{domain}.json"
+    File.exist?(domain_file) ? domain_file : "#{base_dir}/mail-receiver-environment.json"
+  end
+
   def initialize(env_file = nil, recipient = nil, mail = nil)
     super(env_file)
 

--- a/receive-mail
+++ b/receive-mail
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ENV_FILE    = "/etc/postfix/mail-receiver-environment.json"
 EX_TEMPFAIL = 75
 EX_SUCCESS  = 0
 
@@ -9,7 +8,8 @@ require 'mail_receiver/discourse_mail_receiver'
 
 if __FILE__ == $0
   begin
-    receiver = DiscourseMailReceiver.new(ENV_FILE, ARGV.first, $stdin.read)
+    env_file = DiscourseMailReceiver.env_file_for_recipient(ARGV.first)
+    receiver = DiscourseMailReceiver.new(env_file, ARGV.first, $stdin.read)
     exit (receiver.process == :success) ? EX_SUCCESS : EX_TEMPFAIL
 
   rescue StandardError => ex

--- a/spec/fixtures/domain_specific.json
+++ b/spec/fixtures/domain_specific.json
@@ -1,0 +1,5 @@
+{
+	"DISCOURSE_API_KEY": "DOMAIN_KEY",
+	"DISCOURSE_API_USERNAME": "system",
+	"DISCOURSE_BASE_URL": "https://site1.example.com"
+}

--- a/spec/lib/discourse_mail_receiver_spec.rb
+++ b/spec/lib/discourse_mail_receiver_spec.rb
@@ -48,4 +48,32 @@ RSpec.describe DiscourseMailReceiver do
     receiver = described_class.new(file_for(:standard), "eviltrout@example.com", "test mail")
     expect(receiver.process).to eq(:failure)
   end
+
+  describe ".env_file_for_recipient" do
+    let(:fixtures_dir) { File.expand_path("../fixtures", __dir__) }
+
+    it "returns domain-specific file when it exists" do
+      allow(File).to receive(:exist?).and_call_original
+      domain_file = "#{fixtures_dir}/mail-receiver-environment-site1.example.com.json"
+      allow(File).to receive(:exist?).with(domain_file).and_return(true)
+      expect(described_class.env_file_for_recipient("user@site1.example.com", fixtures_dir)).to eq(domain_file)
+    end
+
+    it "falls back to global env file when domain-specific file doesn't exist" do
+      allow(File).to receive(:exist?).and_call_original
+      domain_file = "#{fixtures_dir}/mail-receiver-environment-unknown.com.json"
+      allow(File).to receive(:exist?).with(domain_file).and_return(false)
+      expect(described_class.env_file_for_recipient("user@unknown.com", fixtures_dir)).to eq(
+        "#{fixtures_dir}/mail-receiver-environment.json",
+      )
+    end
+
+    it "handles recipients without an @ sign" do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("#{fixtures_dir}/mail-receiver-environment-.json").and_return(false)
+      expect(described_class.env_file_for_recipient("no-at-sign", fixtures_dir)).to eq(
+        "#{fixtures_dir}/mail-receiver-environment.json",
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- A single mail-receiver container can now deliver mail to multiple Discourse instances
- Per-domain env vars (e.g. `DISCOURSE_BASE_URL_SITE1_COM`) override global vars for each domain
- Falls back to global vars for any setting not specified at the domain level
- Boot script generates per-domain config files and validates each domain individually
- Fully backward compatible — single-site setups require no changes

## Configuration example

```
MAIL_DOMAIN="site1.com site2.net"

DISCOURSE_BASE_URL_SITE1_COM=https://site1.com
DISCOURSE_API_KEY_SITE1_COM=key-for-site1

DISCOURSE_BASE_URL_SITE2_NET=https://site2.net
DISCOURSE_API_KEY_SITE2_NET=key-for-site2

DISCOURSE_API_USERNAME=system  # shared fallback
```

## Test plan

- [ ] All 18 existing + new specs pass (`bundle exec rspec`)
- [ ] Single-site config (no per-domain vars) continues to work unchanged
- [ ] Multi-site config routes each recipient to the correct Discourse instance
- [ ] Boot fails with a clear error if a domain is missing required config

🤖 Generated with [Claude Code](https://claude.com/claude-code)